### PR TITLE
[chore] Updates qt3tests submodule URL to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "XPathTest/assets/qt3tests"]
 	path = XPathTest/assets/qt3tests
-	url = git@github.com:w3c/qt3tests.git
+	url = https://github.com/w3c/qt3tests.git


### PR DESCRIPTION
Switches the qt3tests submodule URL from SSH to HTTPS.

This change ensures that users can access the submodule without needing SSH keys.